### PR TITLE
Shorten long trace section names

### DIFF
--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceMethodVisitor.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceMethodVisitor.kt
@@ -14,7 +14,7 @@ class TraceMethodVisitor(
 
     override fun onMethodEnter() {
         // 插入 Trace.beginSection(String)
-        mv.visitLdcInsn("$className#$methodName")
+        mv.visitLdcInsn("$className#$methodName".takeLast(127))
         mv.visitMethodInsn(
             INVOKESTATIC,
             "android/os/Trace",


### PR DESCRIPTION
public static final int MAX_SECTION_NAME_LEN = 127;

this is maximum allowed. in big project, it is easy to exceed 127 with generated codes.

fixes https://github.com/aidaole/EasyTrace/issues/2