### PR TITLE
Add Suspend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pluginManagement {
 
 **在项目根目录的 `build.gradle` 添加插件**
 
-``` 
+```
 buildscript {
     dependencies {
         classpath("com.github.aidaole:EasyTrace:1.0.2")
@@ -54,10 +54,10 @@ plugins {
 
 easyTrace {
     // 指定包名, 可以指定多个以,分割. 包名下的所有方法都会被插桩, 插桩的方法会比较多
-    // includePackages = ['com.aidaole.easytrace'] 
+    // includePackages = ['com.aidaole.easytrace']
 
     // 指定类名, 可以指定多个以,分割. 类名下的所有方法都会被插桩
-    includeClasses = ['com.aidaole.easytrace.App', 'com.aidaole.easytrace.MainActivity'] 
+    includeClasses = ['com.aidaole.easytrace.App', 'com.aidaole.easytrace.MainActivity']
 }
 ```
 
@@ -80,7 +80,7 @@ EasyTrace git:(main) ✗ ./gradlew :app:installDebug
 
 可以直接将shell目录下的脚本都copy到你自己的项目中
 
-然后使用 `perfetto.sh 包名` 抓取trace日志, 
+然后使用 `perfetto.sh 包名` 抓取trace日志,
 
 注意: 需要手动启动一下应用, 抓取完trace后自己在终端 `ctrl+c` 结束抓取即可
 
@@ -97,3 +97,17 @@ perfetto ui 地址: [https://ui.perfetto.dev](https://ui.perfetto.dev)
 ![](images/README/2025-02-11-11-14-39.png)
 
 这里可以看到启动过程中 App 内内插桩的方法, 这里写了一个斐波那契数列的递归方法, 可以看到这个方法的耗时, 以及调用栈
+
+## 开发说明 (Development)
+
+本项目使用 Gradle Composite Builds (复合构建) 进行开发。
+
+- `easytrace_plugin`: 插件源码
+- `app`: 示例应用
+
+在开发过程中，`app` 模块会直接使用 `easytrace_plugin` 的源码进行构建，无需手动发布到 mavenLocal。
+修改插件代码后，直接运行 `app` 的构建任务即可生效。
+
+```bash
+./gradlew :app:assembleDebug
+```

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,5 @@
+import com.aidaole.easytrace.plugin.CoroutineMode
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -7,6 +9,8 @@ plugins {
 easyTrace {
     includePackages = ['com.aidaole.easytrace']
 //    includeClasses = ['com.aidaole.easytrace.App']
+    coroutineMode = CoroutineMode.ENABLED
+    excludePatterns = ['.*ExcludedClass.*']
 }
 
 android {
@@ -45,6 +49,8 @@ dependencies {
     implementation libs.material
     implementation libs.androidx.activity
     implementation libs.androidx.constraintlayout
+    implementation libs.kotlinx.coroutines.core
+    implementation libs.kotlinx.coroutines.android
     testImplementation libs.junit
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.espresso.core

--- a/app/src/main/java/com/aidaole/easytrace/ExcludedClass.kt
+++ b/app/src/main/java/com/aidaole/easytrace/ExcludedClass.kt
@@ -1,0 +1,7 @@
+package com.aidaole.easytrace
+
+class ExcludedClass {
+    fun shouldNotBeTraced() {
+        println("This method should not be instrumented")
+    }
+}

--- a/app/src/main/java/com/aidaole/easytrace/MainActivity.kt
+++ b/app/src/main/java/com/aidaole/easytrace/MainActivity.kt
@@ -33,6 +33,8 @@ class MainActivity : AppCompatActivity() {
                 "IOException must have no suppressed exceptions, got: ${suppressed.toList()}"
             }
             println("[EasyTrace] PASS: IOException has no suppressed exceptions")
+
+            testEnumRunCatching()
         }
 
         // Test Exclusion
@@ -58,6 +60,35 @@ class MainActivity : AppCompatActivity() {
 
         // This is the real escaped exception — its suppressed list must be empty
         throw IOException("real escaped exception")
+    }
+
+    /**
+     * Mirrors GiftCardApiException.createExceptionType:
+     *   runCatching { ExceptionType.valueOf(unknownString) }.getOrNull()
+     *
+     * Before the fix: IllegalArgumentException escaped runCatching and crashed.
+     * After the fix:  runCatching catches it, getOrNull() returns null.
+     */
+    enum class PaymentErrorType {
+        CardExpired, CardInvalid, CardNotEnabled
+    }
+
+    fun parsePaymentErrorType(raw: String): PaymentErrorType? =
+        runCatching { PaymentErrorType.valueOf(raw) }.getOrNull()
+
+    suspend fun testEnumRunCatching() {
+        // Known value — must resolve correctly
+        val known = parsePaymentErrorType("CardExpired")
+        check(known == PaymentErrorType.CardExpired) { "Expected CardExpired, got $known" }
+
+        // Unknown value — mirrors "ApiOAuthFailedException" from the crash
+        // runCatching must swallow the IllegalArgumentException and return null
+        val unknown = parsePaymentErrorType("ApiOAuthFailedException")
+        check(unknown == null) {
+            "Expected null for unknown enum value, got $unknown"
+        }
+
+        println("[EasyTrace] PASS: runCatching swallowed IllegalArgumentException from Enum.valueOf")
     }
 
     fun fabnic(n: Int): Int {

--- a/app/src/main/java/com/aidaole/easytrace/MainActivity.kt
+++ b/app/src/main/java/com/aidaole/easytrace/MainActivity.kt
@@ -5,6 +5,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,6 +21,19 @@ class MainActivity : AppCompatActivity() {
             insets
         }
         fabnic(20)
+
+        // Test Coroutine Tracing with custom scope
+        CoroutineScope(Dispatchers.Main).launch {
+            heavyWork()
+        }
+
+        // Test Exclusion
+        ExcludedClass().shouldNotBeTraced()
+    }
+
+    suspend fun heavyWork() {
+        delay(100)
+        println("Coroutine work done")
     }
 
     fun fabnic(n: Int): Int {

--- a/app/src/main/java/com/aidaole/easytrace/MainActivity.kt
+++ b/app/src/main/java/com/aidaole/easytrace/MainActivity.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.io.IOException
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,6 +26,13 @@ class MainActivity : AppCompatActivity() {
         // Test Coroutine Tracing with custom scope
         CoroutineScope(Dispatchers.Main).launch {
             heavyWork()
+            val caught = runCatching { testExceptionIsolation() }.exceptionOrNull()
+            check(caught is IOException) { "Expected IOException, got $caught" }
+            val suppressed = caught.suppressed
+            check(suppressed.isEmpty()) {
+                "IOException must have no suppressed exceptions, got: ${suppressed.toList()}"
+            }
+            println("[EasyTrace] PASS: IOException has no suppressed exceptions")
         }
 
         // Test Exclusion
@@ -34,6 +42,22 @@ class MainActivity : AppCompatActivity() {
     suspend fun heavyWork() {
         delay(100)
         println("Coroutine work done")
+    }
+
+    /**
+     * Regression test for coroutine exception suppression bug.
+     *
+     * IllegalArgumentException is caught internally by runCatching — it must NOT
+     * appear as a suppressed exception on the IOException that escapes.
+     */
+    suspend fun testExceptionIsolation() {
+        // This exception is caught internally — never escapes invokeSuspend
+        runCatching { throw IllegalArgumentException("swallowed") }
+
+        delay(10)
+
+        // This is the real escaped exception — its suppressed list must be empty
+        throw IOException("real escaped exception")
     }
 
     fun fabnic(n: Int): Int {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
     dependencies {
-         classpath("com.github.aidaole:EasyTrace:1.0.2")
+        classpath("com.github.aidaole:easytrace:1.0.0")
     }
 }
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    repositories {
-        mavenLocal()
-        google()
-        mavenCentral()
-    }
     dependencies {
-        classpath("com.github.aidaole:easytrace:1.0.0")
+        classpath("com.github.aidaole:easytrace:1.0.2")
     }
 }
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,4 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    dependencies {
-        classpath("com.github.aidaole:easytrace:1.0.2")
-    }
-}
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false

--- a/easytrace_plugin/build.gradle
+++ b/easytrace_plugin/build.gradle
@@ -34,12 +34,10 @@ gradlePlugin {
 
 publishing {
     publications {
-        maven(MavenPublication) {
-            groupId = 'com.github.aidaole'
-            artifactId = "easytrace"
-            version = project.findProperty("version") ?: "1.0.0"
-
-            from components.java
+        pluginMaven(MavenPublication) {
+            groupId = System.getenv("GROUP") ?: 'com.github.aidaole'
+            artifactId = System.getenv("ARTIFACT") ?: 'easytrace'
+            version = System.getenv("VERSION") ?: project.findProperty("version") ?: "1.0.0"
         }
     }
 }

--- a/easytrace_plugin/build.gradle
+++ b/easytrace_plugin/build.gradle
@@ -5,6 +5,9 @@ plugins {
     id 'maven-publish'
 }
 
+group = System.getenv("GROUP") ?: 'com.github.aidaole'
+version = System.getenv("VERSION") ?: "1.0.0"
+
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
@@ -35,9 +38,9 @@ gradlePlugin {
 publishing {
     publications {
         pluginMaven(MavenPublication) {
-            groupId = System.getenv("GROUP") ?: 'com.github.aidaole'
-            artifactId = System.getenv("ARTIFACT") ?: 'easytrace'
-            version = System.getenv("VERSION") ?: project.findProperty("version") ?: "1.0.0"
+            groupId = group
+            artifactId = 'easytrace'
+            version = project.version
         }
     }
 }

--- a/easytrace_plugin/build.gradle
+++ b/easytrace_plugin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'org.jetbrains.kotlin.jvm'
+    alias(libs.plugins.jetbrains.kotlin.jvm)
     id 'java-gradle-plugin'
     id 'maven-publish'
 }
@@ -38,7 +38,7 @@ publishing {
             groupId = 'com.github.aidaole'
             artifactId = "easytrace"
             version = '1.0.0'
-            
+
             from components.java
         }
     }

--- a/easytrace_plugin/build.gradle
+++ b/easytrace_plugin/build.gradle
@@ -37,7 +37,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.github.aidaole'
             artifactId = "easytrace"
-            version = '1.0.0'
+            version = project.findProperty("version") ?: "1.0.0"
 
             from components.java
         }

--- a/easytrace_plugin/settings.gradle
+++ b/easytrace_plugin/settings.gradle
@@ -11,7 +11,6 @@ pluginManagement {
         gradlePluginPortal()
         maven { url 'https://jitpack.io' }
     }
-    includeBuild("easytrace_plugin")
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
@@ -20,7 +19,11 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { url 'https://jitpack.io' }
     }
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
 }
 
-rootProject.name = "EasyTrace"
-include ':app'
+rootProject.name = 'easytrace_plugin'

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/CoroutineMode.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/CoroutineMode.kt
@@ -1,0 +1,14 @@
+package com.aidaole.easytrace.plugin
+
+enum class CoroutineMode {
+    /**
+     * Use TraceMethodVisitor with try-finally guarantee.
+     * Each resumption of a coroutine gets its own fully closed flat trace section.
+     */
+    ENABLED,
+
+    /**
+     * Do not instrument invokeSuspend on coroutine state machine classes at all.
+     */
+    DISABLED
+}

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/CoroutineTraceMethodVisitor.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/CoroutineTraceMethodVisitor.kt
@@ -1,0 +1,78 @@
+package com.aidaole.easytrace.plugin
+
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+/**
+ * Pure try/finally instrumentation for coroutine invokeSuspend methods:
+ *
+ *   Trace.beginSection(label)
+ *   try {
+ *       invokeSuspend(...)
+ *   } finally {
+ *       Trace.endSection()
+ *   }
+ *
+ * Extends MethodVisitor directly — no AdviceAdapter, no per-ATHROW hooks.
+ *
+ * CRITICAL: visitTryCatchBlock is called in visitMaxs (not visitCode) so that
+ * our catch-all is the LAST entry in the exception table. The JVM scans handlers
+ * top-to-bottom and takes the first match, so internal handlers (runCatching,
+ * try-catch) registered during method body visitation come first and take priority.
+ * Registering our handler first would make it intercept exceptions before internal
+ * handlers could catch them.
+ */
+class CoroutineTraceMethodVisitor(
+    methodVisitor: MethodVisitor,
+    access: Int,
+    private val className: String,
+    private val methodName: String,
+    descriptor: String,
+) : MethodVisitor(Opcodes.ASM9, methodVisitor) {
+
+    private val tryStart = Label()
+    private val tryEnd = Label()
+    private val handler = Label()
+    private val handlerLocals: Array<Any> = TraceMethodVisitor.buildLocals(
+        className, descriptor, (access and Opcodes.ACC_STATIC) != 0
+    )
+
+    override fun visitCode() {
+        super.visitCode()
+        // beginSection + tryStart — do NOT call visitTryCatchBlock here, that would
+        // put our catch-all first in the table, before internal handlers.
+        mv.visitLdcInsn("$className#$methodName".takeLast(127))
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, "android/os/Trace", "beginSection", "(Ljava/lang/String;)V", false)
+        mv.visitLabel(tryStart)
+    }
+
+    override fun visitInsn(opcode: Int) {
+        // finally-normal path: endSection before every return
+        if (opcode == Opcodes.RETURN || opcode == Opcodes.IRETURN || opcode == Opcodes.LRETURN ||
+            opcode == Opcodes.FRETURN || opcode == Opcodes.DRETURN || opcode == Opcodes.ARETURN
+        ) {
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC, "android/os/Trace", "endSection", "()V", false)
+        }
+        super.visitInsn(opcode)
+    }
+
+    override fun visitMaxs(maxStack: Int, maxLocals: Int) {
+        // Register catch-all LAST — after all method body handlers — so internal
+        // handlers (runCatching, try-catch) have higher priority in the JVM table.
+        mv.visitTryCatchBlock(tryStart, tryEnd, handler, null)
+        // finally-exceptional path
+        mv.visitLabel(tryEnd)
+        mv.visitLabel(handler)
+        mv.visitFrame(
+            Opcodes.F_NEW,
+            handlerLocals.size,
+            handlerLocals,
+            1,
+            arrayOf<Any>("java/lang/Throwable")
+        )
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, "android/os/Trace", "endSection", "()V", false)
+        mv.visitInsn(Opcodes.ATHROW)
+        super.visitMaxs(maxStack + 1, maxLocals) // +1 for the Throwable on the stack
+    }
+}

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/EasyTraceExtension.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/EasyTraceExtension.kt
@@ -3,4 +3,19 @@ package com.aidaole.easytrace.plugin
 open class EasyTraceExtension {
     var includePackages: List<String> = listOf()
     var includeClasses: List<String> = listOf()
-} 
+
+    /**
+     * Regex patterns for fully-qualified class names to exclude from instrumentation.
+     */
+    var excludePatterns: List<String> = listOf()
+
+    /**
+     * How to handle Kotlin coroutine state machine classes (identified by class names ending in $N).
+     *
+     * ENABLED (default): Use CoroutineTraceMethodVisitor with try-finally guarantee.
+     *   Each resumption of a coroutine gets its own fully closed flat trace section.
+     *
+     * DISABLED: Do not instrument invokeSuspend on coroutine state machine classes at all.
+     */
+    var coroutineMode: CoroutineMode = CoroutineMode.ENABLED
+}

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/EasyTracePlugin.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/EasyTracePlugin.kt
@@ -9,7 +9,7 @@ class EasyTracePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         // 创建扩展
         val extension = project.extensions.create("easyTrace", EasyTraceExtension::class.java)
-        
+
         val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
         androidComponents.onVariants { variant ->
             variant.instrumentation.transformClassesWith(
@@ -18,6 +18,8 @@ class EasyTracePlugin : Plugin<Project> {
             ) { params ->
                 params.includePackages.set(extension.includePackages)
                 params.includeClasses.set(extension.includeClasses)
+                params.excludePatterns.set(extension.excludePatterns)
+                params.coroutineMode.set(extension.coroutineMode)
             }
         }
     }

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceClassVisitor.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceClassVisitor.kt
@@ -4,20 +4,23 @@ import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
+private val COROUTINE_STATE_MACHINE_REGEX = Regex(""".*\$\d+$""")
+
 class TraceClassVisitor(
     nextVisitor: ClassVisitor,
-    private val className: String
+    private val className: String,
+    private val coroutineMode: CoroutineMode,
 ) : ClassVisitor(Opcodes.ASM9, nextVisitor) {
 
+    private val isCoroutineStateMachine: Boolean =
+        className.substringAfterLast('.').matches(COROUTINE_STATE_MACHINE_REGEX)
+
     override fun visitMethod(
-        access: Int,
-        name: String,
-        descriptor: String,
-        signature: String?,
-        exceptions: Array<out String>?
+        access: Int, name: String, descriptor: String,
+        signature: String?, exceptions: Array<out String>?
     ): MethodVisitor {
         val methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions)
-        
+
         // 跳过以下方法：
         // 1. 构造方法
         // 2. 静态初始化方法
@@ -27,6 +30,16 @@ class TraceClassVisitor(
         // 6. lambda 表达式
         if (shouldSkipMethod(access, name)) {
             return methodVisitor
+        }
+
+        if (isCoroutineStateMachine && name == "invokeSuspend") {
+            return when (coroutineMode) {
+                CoroutineMode.DISABLED -> methodVisitor
+                CoroutineMode.ENABLED -> {
+                    println("[EasyTrace] Adding coroutine trace to: $className#$name$descriptor")
+                    TraceMethodVisitor(methodVisitor, access, className, name, descriptor)
+                }
+            }
         }
 
         println("[EasyTrace] Adding trace to method: $className#$name$descriptor")
@@ -49,4 +62,4 @@ class TraceClassVisitor(
                 name.contains("$") || // lambda 表达式
                 name.length <= 2 // 过短的方法名
     }
-} 
+}

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceClassVisitor.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceClassVisitor.kt
@@ -37,7 +37,13 @@ class TraceClassVisitor(
                 CoroutineMode.DISABLED -> methodVisitor
                 CoroutineMode.ENABLED -> {
                     println("[EasyTrace] Adding coroutine trace to: $className#$name$descriptor")
-                    TraceMethodVisitor(methodVisitor, access, className, name, descriptor)
+                    CoroutineTraceMethodVisitor(
+                        methodVisitor,
+                        access,
+                        className,
+                        name,
+                        descriptor
+                    )
                 }
             }
         }

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceClassVisitorFactory.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceClassVisitorFactory.kt
@@ -6,32 +6,23 @@ import com.android.build.api.instrumentation.ClassData
 import org.objectweb.asm.ClassVisitor
 
 abstract class TraceClassVisitorFactory : AsmClassVisitorFactory<TraceParameters> {
-    override fun createClassVisitor(
-        classContext: ClassContext,
-        nextClassVisitor: ClassVisitor
-    ): ClassVisitor {
+
+    override fun createClassVisitor(classContext: ClassContext, nextClassVisitor: ClassVisitor): ClassVisitor {
         val className = classContext.currentClassData.className
+        val coroutineMode = parameters.get().coroutineMode.get()
         print("Start processing class: $className")
-        return TraceClassVisitor(nextClassVisitor, className)
+        return TraceClassVisitor(nextClassVisitor, className, coroutineMode)
     }
 
     override fun isInstrumentable(classData: ClassData): Boolean {
         val className = classData.className
-        
-        // 检查是否在包名列表中
-        val isInPackages = parameters.get().includePackages.get().any { packageName ->
-            className.startsWith(packageName)
-        }
-        
-        // 检查是否在类名列表中
-        val isInClasses = parameters.get().includeClasses.get().any { targetClass ->
-            className == targetClass
-        }
-        
-        // 包名或类名匹配其一即可
-        val shouldInclude = isInPackages || isInClasses
-        
-        val isInstrumentable = shouldInclude &&
+
+        val isInPackages = parameters.get().includePackages.get().any { className.startsWith(it) }
+        val isInClasses  = parameters.get().includeClasses.get().any  { className == it }
+        val isExcluded   = parameters.get().excludePatterns.get().any { className.matches(Regex(it)) }
+
+        val isInstrumentable = (isInPackages || isInClasses) &&
+                !isExcluded &&
                 !className.endsWith(".R") &&
                 !className.contains(".R\$") &&
                 !className.endsWith(".BuildConfig") &&
@@ -42,4 +33,4 @@ abstract class TraceClassVisitorFactory : AsmClassVisitorFactory<TraceParameters
         }
         return isInstrumentable
     }
-} 
+}

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceMethodVisitor.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceMethodVisitor.kt
@@ -1,7 +1,9 @@
 package com.aidaole.easytrace.plugin
 
+import org.objectweb.asm.Label
 import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
 import org.objectweb.asm.commons.AdviceAdapter
 
 class TraceMethodVisitor(
@@ -12,8 +14,19 @@ class TraceMethodVisitor(
     descriptor: String
 ) : AdviceAdapter(Opcodes.ASM9, methodVisitor, access, methodName, descriptor) {
 
+    private val tryStart = Label()
+    private val tryEnd = Label()
+    private val handler = Label()
+
+    // Pre-compute the locals array for the F_NEW handler frame.
+    private val handlerLocals: Array<Any> = buildLocals(
+        className, descriptor, (access and Opcodes.ACC_STATIC) != 0
+    )
+
     override fun onMethodEnter() {
-        // 插入 Trace.beginSection(String)
+        // Register the handler BEFORE placing tryStart so the ClassWriter
+        // knows about it when writing the exception table.
+        mv.visitTryCatchBlock(tryStart, tryEnd, handler, null) // null = catch all Throwables
         mv.visitLdcInsn("$className#$methodName".takeLast(127))
         mv.visitMethodInsn(
             INVOKESTATIC,
@@ -22,10 +35,33 @@ class TraceMethodVisitor(
             "(Ljava/lang/String;)V",
             false
         )
+        mv.visitLabel(tryStart)
     }
 
     override fun onMethodExit(opcode: Int) {
-        // 插入 Trace.endSection()
+        if (opcode != ATHROW) {
+            mv.visitMethodInsn(
+                INVOKESTATIC,
+                "android/os/Trace",
+                "endSection",
+                "()V",
+                false
+            )
+        }
+    }
+
+    override fun visitMaxs(maxStack: Int, maxLocals: Int) {
+        mv.visitLabel(tryEnd)
+        mv.visitLabel(handler)
+        // Explicit F_NEW frame required because AGP's ClassWriter uses COMPUTE_MAXS
+        mv.visitFrame(
+            Opcodes.F_NEW,
+            handlerLocals.size,
+            handlerLocals,
+            1,
+            arrayOf<Any>("java/lang/Throwable")
+        )
+        // Stack: [Throwable] — endSection() has no args so it doesn't disturb the stack.
         mv.visitMethodInsn(
             INVOKESTATIC,
             "android/os/Trace",
@@ -33,5 +69,29 @@ class TraceMethodVisitor(
             "()V",
             false
         )
+        mv.visitInsn(ATHROW) // re-throw
+        super.visitMaxs(maxStack + 1, maxLocals) // +1 for the Throwable on the stack
     }
-} 
+
+    companion object {
+
+        /** Build the locals array for the F_FULL catch-handler frame from the method descriptor. */
+        fun buildLocals(className: String, descriptor: String, isStatic: Boolean): Array<Any> {
+            val locals = mutableListOf<Any>()
+            if (!isStatic) locals.add(className.replace('.', '/'))
+            for (t in Type.getArgumentTypes(descriptor)) {
+                locals.add(
+                    when (t.sort) {
+                        Type.BOOLEAN, Type.BYTE, Type.CHAR, Type.SHORT, Type.INT -> Opcodes.INTEGER
+                        Type.LONG -> Opcodes.LONG
+                        Type.FLOAT -> Opcodes.FLOAT
+                        Type.DOUBLE -> Opcodes.DOUBLE
+                        Type.ARRAY -> t.descriptor
+                        else -> t.internalName // OBJECT
+                    }
+                )
+            }
+            return locals.toTypedArray()
+        }
+    }
+}

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceMethodVisitor.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceMethodVisitor.kt
@@ -24,9 +24,7 @@ class TraceMethodVisitor(
     )
 
     override fun onMethodEnter() {
-        // Register the handler BEFORE placing tryStart so the ClassWriter
-        // knows about it when writing the exception table.
-        mv.visitTryCatchBlock(tryStart, tryEnd, handler, null) // null = catch all Throwables
+        // 插入 Trace.beginSection(String)
         mv.visitLdcInsn("$className#$methodName".takeLast(127))
         mv.visitMethodInsn(
             INVOKESTATIC,
@@ -51,6 +49,12 @@ class TraceMethodVisitor(
     }
 
     override fun visitMaxs(maxStack: Int, maxLocals: Int) {
+        // Register catch-all LAST — after all method body handlers have been registered
+        // during body visitation — so internal try-catch blocks have higher priority.
+        // The JVM scans the exception table top-to-bottom and takes the first match;
+        // if our catch-all were first, it would intercept exceptions before internal
+        // handlers (runCatching, try-catch) could catch them.
+        mv.visitTryCatchBlock(tryStart, tryEnd, handler, null)
         mv.visitLabel(tryEnd)
         mv.visitLabel(handler)
         // Explicit F_NEW frame required because AGP's ClassWriter uses COMPUTE_MAXS

--- a/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceParameters.kt
+++ b/easytrace_plugin/src/main/java/com/aidaole/easytrace/plugin/TraceParameters.kt
@@ -2,12 +2,19 @@ package com.aidaole.easytrace.plugin
 
 import com.android.build.api.instrumentation.InstrumentationParameters
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 
 interface TraceParameters : InstrumentationParameters {
     @get:Input
     val includePackages: ListProperty<String>
-    
+
     @get:Input
     val includeClasses: ListProperty<String>
-} 
+
+    @get:Input
+    val excludePatterns: ListProperty<String>
+
+    @get:Input
+    val coroutineMode: Property<CoroutineMode>
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,9 +10,12 @@ material = "1.12.0"
 activity = "1.8.0"
 constraintlayout = "2.2.0"
 jetbrainsKotlinJvm = "1.9.24"
+coroutines = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,4 @@
 jdk:
   - openjdk17
+install:
+  - ./gradlew :easytrace_plugin:publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk17
 install:
-  - ./gradlew :easytrace_plugin:publishToMavenLocal
+  - ./gradlew -p easytrace_plugin publishToMavenLocal


### PR DESCRIPTION
This PR adds two new values to EasyTrace extension. 

One to enable suspend support wrap the suspending functions differently then regular functions.
other is for excluding classes.

This PR also reform the gradle plugin setup and current sample directly depends on the plugin from the source.

Fixes #5